### PR TITLE
[Redux] Remove description to use useCallback

### DIFF
--- a/docs/redux/contents/11_react_redux_exercise.md
+++ b/docs/redux/contents/11_react_redux_exercise.md
@@ -28,5 +28,5 @@ Reactとreduxを接続するための処理を確認する。
     - `store.todos`からIDが一致するアイテムを除外する。
       - `store.todos`は`Todo`の配列である。
 - src/components/Todo.js
-  - `useCallback`を用いて`handleDeleteTodo`を定義する。
+  - `handleDeleteTodo`を定義する。
   - `<span>❎<span>`に`onClick`イベントを追加する。


### PR DESCRIPTION
Reduxの実習の指示を微修正します。
`<select>`要素のイベントハンドラにuseCallbackを用いる実装は不要のため廃止しました。