### PR TITLE
[#26] Redux 2022 content app back to base

### DIFF
--- a/redux/src/app/hooks.ts
+++ b/redux/src/app/hooks.ts
@@ -1,7 +1,11 @@
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import {
+  TypedUseSelectorHook,
+  useDispatch as useDispatchOriginal,
+  useSelector as useSelectorOriginal,
+} from 'react-redux';
 
 import type { RootState, AppDispatch } from './store';
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = () => useDispatch<AppDispatch>();
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const useDispatch = () => useDispatchOriginal<AppDispatch>();
+export const useSelector: TypedUseSelectorHook<RootState> = useSelectorOriginal;

--- a/redux/src/components/AuthorCreateForm/index.tsx
+++ b/redux/src/components/AuthorCreateForm/index.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 
-import { useAppDispatch } from '../../app/hooks';
+import { useDispatch } from '../../app/hooks';
 import {
   createAuthorAsync,
 } from '../../slices/authors';
 import { Presenter } from './Presenter';
 
 export function AuthorCreateForm() {
-  const dispatch = useAppDispatch()
+  const dispatch = useDispatch()
 
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')

--- a/redux/src/components/AuthorsTable/index.tsx
+++ b/redux/src/components/AuthorsTable/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { useAppSelector, useAppDispatch } from '../../app/hooks';
+import { useSelector, useDispatch } from '../../app/hooks';
 import {
   fetchAuthorsAsync,
   selectAuthors,
@@ -8,8 +8,8 @@ import {
 import { Presenter } from './Presenter';
 
 export function AuthorsTable() {
-  const authors = useAppSelector(selectAuthors);
-  const dispatch = useAppDispatch();
+  const authors = useSelector(selectAuthors);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(fetchAuthorsAsync())

--- a/redux/src/components/AuthorsTable/index.tsx
+++ b/redux/src/components/AuthorsTable/index.tsx
@@ -4,20 +4,16 @@ import { useAppSelector, useAppDispatch } from '../../app/hooks';
 import {
   fetchAuthorsAsync,
   selectAuthors,
-  selectAuthorsStatus,
 } from '../../slices/authors';
 import { Presenter } from './Presenter';
 
 export function AuthorsTable() {
   const authors = useAppSelector(selectAuthors);
-  const authorsStatus = useAppSelector(selectAuthorsStatus);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (authorsStatus === 'initial') {
-      dispatch(fetchAuthorsAsync())
-    }
-  }, [dispatch, authorsStatus])
+    dispatch(fetchAuthorsAsync())
+  }, [dispatch])
 
   return (<Presenter
     {

--- a/redux/src/components/BookCreateForm/index.tsx
+++ b/redux/src/components/BookCreateForm/index.tsx
@@ -1,10 +1,14 @@
 import React, { useEffect, useState } from 'react';
 
 import { useDispatch, useSelector } from '../../app/hooks';
-import { fetchAuthorsAsync, selectAuthors, selectAuthorsStatus } from '../../slices/authors';
-import {
-  createBookAsync,
-} from '../../slices/books';
+import { fetchAuthorsAsync, selectAuthors } from '../../slices/authors';
+
+// createBookAsync actionをimportしてください。
+
+// import {
+//   createBookAsync,
+// } from '../../slices/books';
+
 import { Presenter } from './Presenter';
 
 export function BookCreateForm() {

--- a/redux/src/components/BookCreateForm/index.tsx
+++ b/redux/src/components/BookCreateForm/index.tsx
@@ -16,10 +16,8 @@ export function BookCreateForm() {
   const [authorId, setAuthorId] = useState<number>(authors[0]?.id)
 
   useEffect(() => {
-    if (authorsStatus === 'initial') {
-      dispatch(fetchAuthorsAsync())
-    }
-  }, [dispatch, authorsStatus])
+    dispatch(fetchAuthorsAsync())
+  }, [dispatch])
 
   useEffect(() => {
     if (authorId == null) {

--- a/redux/src/components/BookCreateForm/index.tsx
+++ b/redux/src/components/BookCreateForm/index.tsx
@@ -9,7 +9,6 @@ import { Presenter } from './Presenter';
 
 export function BookCreateForm() {
   const authors = useAppSelector(selectAuthors);
-  const authorsStatus = useAppSelector(selectAuthorsStatus);
   const dispatch = useAppDispatch();
 
   const [title, setTitle] = useState('')
@@ -25,7 +24,9 @@ export function BookCreateForm() {
     }
   }, [authorId, authors])
 
-  const createBook = (title: string, authorId: number) => { dispatch(createBookAsync({ title, authorId })) }
+  const createBook = (title: string, authorId: number) => {
+    // 本を作成する処理を追加してください。
+  }
 
   return (<Presenter
     {

--- a/redux/src/components/BookCreateForm/index.tsx
+++ b/redux/src/components/BookCreateForm/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { useAppDispatch, useAppSelector } from '../../app/hooks';
+import { useDispatch, useSelector } from '../../app/hooks';
 import { fetchAuthorsAsync, selectAuthors, selectAuthorsStatus } from '../../slices/authors';
 import {
   createBookAsync,
@@ -8,8 +8,8 @@ import {
 import { Presenter } from './Presenter';
 
 export function BookCreateForm() {
-  const authors = useAppSelector(selectAuthors);
-  const dispatch = useAppDispatch();
+  const authors = useSelector(selectAuthors);
+  const dispatch = useDispatch();
 
   const [title, setTitle] = useState('')
   const [authorId, setAuthorId] = useState<number>(authors[0]?.id)

--- a/redux/src/components/BooksTable/index.tsx
+++ b/redux/src/components/BooksTable/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { useAppSelector, useAppDispatch } from '../../app/hooks';
+import { useSelector, useDispatch } from '../../app/hooks';
 import { fetchAuthorsAsync, selectAuthors } from '../../slices/authors';
 import { fetchBooksAsync, selectBooks } from '../../slices/books';
 import { Presenter } from './Presenter';

--- a/redux/src/components/BooksTable/index.tsx
+++ b/redux/src/components/BooksTable/index.tsx
@@ -1,29 +1,19 @@
 import React, { useEffect } from 'react';
 
 import { useAppSelector, useAppDispatch } from '../../app/hooks';
-import { fetchAuthorsAsync, selectAuthors, selectAuthorsStatus } from '../../slices/authors';
-import {
-  fetchBooksAsync,
-  selectBooks,
-  selectBooksStatus,
-} from '../../slices/books';
+import { fetchAuthorsAsync, selectAuthors } from '../../slices/authors';
+import { fetchBooksAsync, selectBooks } from '../../slices/books';
 import { Presenter } from './Presenter';
 
 export function BooksTable() {
   const authors = useAppSelector(selectAuthors);
-  const authorsStatus = useAppSelector(selectAuthorsStatus);
   const books = useAppSelector(selectBooks);
-  const booksStatus = useAppSelector(selectBooksStatus);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (authorsStatus === 'initial') {
-      dispatch(fetchAuthorsAsync())
-    }
-    if (booksStatus === 'initial') {
-      dispatch(fetchBooksAsync())
-    }
-  }, [dispatch, authorsStatus, booksStatus])
+    dispatch(fetchAuthorsAsync())
+    dispatch(fetchBooksAsync())
+  }, [dispatch])
 
   return (<Presenter
     {

--- a/redux/src/components/BooksTable/index.tsx
+++ b/redux/src/components/BooksTable/index.tsx
@@ -6,21 +6,24 @@ import { fetchBooksAsync, selectBooks } from '../../slices/books';
 import { Presenter } from './Presenter';
 
 export function BooksTable() {
-  const authors = useAppSelector(selectAuthors);
-  const books = useAppSelector(selectBooks);
-  const dispatch = useAppDispatch();
+  // useSelectorでデータを取得するロジックを指定してください。
+  const authors = []
+  const books = []
+
+  // useDispatchでdispatchを参照してください。
+  const dispatch = null
 
   useEffect(() => {
-    dispatch(fetchAuthorsAsync())
-    dispatch(fetchBooksAsync())
+    // 初回読み込み時にデータを取得してください。
+    // dispatch(action)を追加してください。
   }, [dispatch])
 
   return (<Presenter
     {
       ...{
         states: {
-          authors,
-          books,
+          authors: [],
+          books: [],
         }
       }
     }

--- a/redux/src/components/BooksTable/index.tsx
+++ b/redux/src/components/BooksTable/index.tsx
@@ -1,14 +1,15 @@
 import React, { useEffect } from 'react';
 
-import { useSelector, useDispatch } from '../../app/hooks';
-import { fetchAuthorsAsync, selectAuthors } from '../../slices/authors';
-import { fetchBooksAsync, selectBooks } from '../../slices/books';
+// hooksとactionをimportしてください。
+// import { useSelector, useDispatch } from '../../app/hooks';
+// import { fetchAuthorsAsync, selectAuthors } from '../../slices/authors';
+// import { fetchBooksAsync, selectBooks } from '../../slices/books';
 import { Presenter } from './Presenter';
 
 export function BooksTable() {
   // useSelectorでデータを取得するロジックを指定してください。
-  const authors = []
-  const books = []
+  // const authors = ...
+  // const books = ...
 
   // useDispatchでdispatchを参照してください。
   const dispatch = null

--- a/redux/src/slices/authors/index.ts
+++ b/redux/src/slices/authors/index.ts
@@ -7,12 +7,12 @@ import Action from '../../util/models/Action';
 
 export interface AuthorsState {
   value: Author[];
-  status: 'initial' | 'idle' | 'loading' | 'failed';
+  status: 'idle' | 'loading' | 'failed';
 }
 
 const initialState: AuthorsState = {
   value: [],
-  status: 'initial',
+  status: 'idle',
 };
 
 export const fetchAuthorsAsync = createAsyncThunk(

--- a/redux/src/slices/authors/index.ts
+++ b/redux/src/slices/authors/index.ts
@@ -3,6 +3,7 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { fetchAuthors, createAuthor } from '../../apis/authors';
 import { RootState } from '../../app/store';
 import { Author, AuthorCreateRequest } from '../../models/Author';
+import Action from '../../util/models/Action';
 
 export interface AuthorsState {
   value: Author[];
@@ -30,25 +31,30 @@ export const createAuthorAsync = createAsyncThunk(
   }
 );
 
+const mockFetchAuthors =
+  (fn: ((state: AuthorsState, action?: Action<Author[]>) => AuthorsState)) =>
+  (state: AuthorsState, action?: Action<Author[]>) =>
+  state.value.length ? state : fn(state, action)
+
 export const authorsSlice = createSlice({
   name: 'authors',
   initialState,
   reducers: {},
   extraReducers: (builder) => {
     builder
-      .addCase(fetchAuthorsAsync.pending, (state) => ({
+      .addCase(fetchAuthorsAsync.pending, mockFetchAuthors((state) => ({
         ...state,
         status: 'loading',
-      }))
-      .addCase(fetchAuthorsAsync.fulfilled, (state, action) => ({
+      })))
+      .addCase(fetchAuthorsAsync.fulfilled, mockFetchAuthors((state, action) => ({
         ...state,
         status: 'idle',
-        value: action.payload,
-      }))
-      .addCase(fetchAuthorsAsync.rejected, (state) => ({
+        value: action?.payload as Author[],
+      })))
+      .addCase(fetchAuthorsAsync.rejected, mockFetchAuthors((state) => ({
         ...state,
         status: 'failed',
-      }))
+      })))
       .addCase(createAuthorAsync.pending, (state) => ({
         ...state,
         status: 'loading',

--- a/redux/src/slices/books/index.ts
+++ b/redux/src/slices/books/index.ts
@@ -1,5 +1,4 @@
-import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { WritableDraft } from 'immer/dist/internal';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import { fetchBooks, createBook } from '../../apis/books';
 import { RootState } from '../../app/store';

--- a/redux/src/slices/books/index.ts
+++ b/redux/src/slices/books/index.ts
@@ -8,12 +8,12 @@ import Action from '../../util/models/Action';
 
 export interface BooksState {
   value: Book[];
-  status: 'initial' | 'idle' | 'loading' | 'failed';
+  status: 'idle' | 'loading' | 'failed';
 }
 
 const initialState: BooksState = {
   value: [],
-  status: 'initial',
+  status: 'idle',
 };
 
 export const fetchBooksAsync = createAsyncThunk(

--- a/redux/src/slices/books/index.ts
+++ b/redux/src/slices/books/index.ts
@@ -1,9 +1,10 @@
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { Stream } from 'stream';
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { WritableDraft } from 'immer/dist/internal';
 
 import { fetchBooks, createBook } from '../../apis/books';
 import { RootState } from '../../app/store';
 import { Book, BookCreateRequest } from '../../models/Book';
+import Action from '../../util/models/Action';
 
 export interface BooksState {
   value: Book[];
@@ -31,25 +32,30 @@ export const createBookAsync = createAsyncThunk(
   }
 );
 
+const mockFetchBooks =
+  (fn: ((state: BooksState, action?: Action<Book[]>) => BooksState)) =>
+  (state: BooksState, action?: Action<Book[]>) =>
+  state.value.length ? state : fn(state, action)
+
 export const booksSlice = createSlice({
   name: 'books',
   initialState,
   reducers: {},
   extraReducers: (builder) => {
     builder
-      .addCase(fetchBooksAsync.pending, (state) => ({
+      .addCase(fetchBooksAsync.pending, mockFetchBooks((state) => ({
         ...state,
         status: 'loading',
-      }))
-      .addCase(fetchBooksAsync.fulfilled, (state, action) => ({
+      })))
+      .addCase(fetchBooksAsync.fulfilled, mockFetchBooks((state, action) => ({
         ...state,
         status: 'idle',
-        value: action.payload,
-      }))
-      .addCase(fetchBooksAsync.rejected, (state) => ({
+        value: action?.payload as Book[],
+      })))
+      .addCase(fetchBooksAsync.rejected, mockFetchBooks((state) => ({
         ...state,
         status: 'failed',
-      }))
+      })))
       .addCase(createBookAsync.pending, (state) => ({
         ...state,
         status: 'loading',

--- a/redux/src/util/models/Action.ts
+++ b/redux/src/util/models/Action.ts
@@ -1,0 +1,9 @@
+import { PayloadAction } from "@reduxjs/toolkit";
+
+type Pending = PayloadAction<unknown, string, { arg: void; requestId: string; requestStatus: 'pending'; }, never>
+type Fulfilled<T> = PayloadAction<T, string, { arg: void; requestId: string; requestStatus: 'fulfilled'; }, never>
+type Rejected = PayloadAction<unknown, string, { arg: void; requestId: string; requestStatus: 'rejected'; }, never>
+
+type Action<T> = Pending | Fulfilled<T> | Rejected
+
+export default Action


### PR DESCRIPTION
## Pull Request for issue #26

## 更新内容

研修用にmock APIを使っていることに依存した実装は本質ではないので、それ用のwrapperで解決するようにしました。 9712cf344e224506551ad947730601c98f732d0c 156666218ebe4ddec1b5770d9f6a15a7125ab1da
演習問題前の状態にしました。 [7497fa1](https://github.com/access-company/webfrontend_intro/pull/33/commits/7497fa19555477ba8a09026c31206455e597a859)