### PR TITLE
nodeのバージョンを16.20.0に変更

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "typescript-training",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-training",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "node": "^16.20.0"
+      },
+      "devDependencies": {
+        "@types/node": "^15.0.2",
+        "typescript": "^4.2.4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
+      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "dev": true
+    },
+    "node_modules/node": {
+      "version": "16.20.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-16.20.0.tgz",
+      "integrity": "sha512-dom1A0xPnc1qzE+voYGswg3afb5QzlQxsPqE2b94BUcZZ6I5+v1EzqV0wHo7mXM1YzFTJOLshOwyAlouNEk3tA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-bin-setup": "^1.0.0"
+      },
+      "bin": {
+        "node": "bin/node"
+      },
+      "engines": {
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/node-bin-setup": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
+      "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg=="
+    },
+    "node_modules/typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "tsc"
   },
-  "dependencies": {},
+  "dependencies": {
+    "node": "^16.20.0"
+  },
   "devDependencies": {
     "@types/node": "^15.0.2",
     "typescript": "^4.2.4"

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -4,10 +4,22 @@
 
 "@types/node@^15.0.2":
   version "15.0.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.2.tgz#51e9c0920d1b45936ea04341aa3e2e58d339fb67"
+  resolved "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz"
   integrity sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==
+
+node-bin-setup@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz"
+  integrity sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg==
+
+node@^16.20.0:
+  version "16.20.0"
+  resolved "https://registry.npmjs.org/node/-/node-16.20.0.tgz"
+  integrity sha512-dom1A0xPnc1qzE+voYGswg3afb5QzlQxsPqE2b94BUcZZ6I5+v1EzqV0wHo7mXM1YzFTJOLshOwyAlouNEk3tA==
+  dependencies:
+    node-bin-setup "^1.0.0"
 
 typescript@^4.2.4:
   version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==


### PR DESCRIPTION
# 注意

Public リポジトリなので社内の情報をコミットしないでください。

## Pull Request for issue #

## 更新内容

nodeのバージョンを15から16.20.0に変更
4/6の定例で16.20.0にすることとなった。（[議事録](https://docs.google.com/document/d/1cO5GUN7SjrcGSNbRAweWxrcAulvph7ob07YCDKHN488/edit#heading=h.2p3r96htwxz)）

