### PR TITLE
React公式Documentへのリンクの修正+15章の内容の充実

### DIFF
--- a/react/docs/config.js
+++ b/react/docs/config.js
@@ -59,7 +59,7 @@ const config = {
       },
       {
         text: 'React公式 スタートガイド',
-        link: 'https://ja.reactjs.org/docs/getting-started.html',
+        link: 'https://ja.react.dev/learn',
       },
       {
         text: 'CodePen',

--- a/react/docs/content/toc/15_advanced.md
+++ b/react/docs/content/toc/15_advanced.md
@@ -9,4 +9,8 @@ title: 第15章　高度なアプリケーション実装に向けて
 - [Web フロントエンドのテスト概論](https://drive.google.com/file/d/1f0AzH_RxWK4b2u2aP4JcQfJO4utpUfwd/view?usp=sharing)
   - Web フロントエンドのさまざまなテスト手法・テストライブラリについての紹介（社内勉強会）
 - [The Future of CSS Layouts](https://drive.google.com/file/d/16fD2uiX35HOoZfM6W1sMMqtGXz5G-Dbm/view?usp=sharing)
+
   - CSS レイアウト手法の今についての紹介（社内勉強会）
+
+- [React Developer Roadmap](https://roadmap.sh/react)
+  - React 開発者になるための学習ロードマップ

--- a/react/docs/content/toc/15_advanced.md
+++ b/react/docs/content/toc/15_advanced.md
@@ -11,4 +11,4 @@ title: 第15章　高度なアプリケーション実装に向けて
 - [The Future of CSS Layouts](https://drive.google.com/file/d/16fD2uiX35HOoZfM6W1sMMqtGXz5G-Dbm/view?usp=sharing)
   - CSS レイアウト手法の今についての紹介（社内勉強会）
 - [React Developer Roadmap](https://roadmap.sh/react)
-  - React 開発者になるための学習ロードマップ
+  - React 開発者として進むべき学習ロードマップ

--- a/react/docs/content/toc/15_advanced.md
+++ b/react/docs/content/toc/15_advanced.md
@@ -9,8 +9,6 @@ title: 第15章　高度なアプリケーション実装に向けて
 - [Web フロントエンドのテスト概論](https://drive.google.com/file/d/1f0AzH_RxWK4b2u2aP4JcQfJO4utpUfwd/view?usp=sharing)
   - Web フロントエンドのさまざまなテスト手法・テストライブラリについての紹介（社内勉強会）
 - [The Future of CSS Layouts](https://drive.google.com/file/d/16fD2uiX35HOoZfM6W1sMMqtGXz5G-Dbm/view?usp=sharing)
-
   - CSS レイアウト手法の今についての紹介（社内勉強会）
-
 - [React Developer Roadmap](https://roadmap.sh/react)
   - React 開発者になるための学習ロードマップ


### PR DESCRIPTION
## 更新内容

- React研修のサイドバーの公式ドキュメントへのリンクを新しいドキュメントに変更
- 15章にReactのロードマップを追加
  - 2025/3/27の定例で追加することになりました。