### PR TITLE
EX2のstorybookの記載形式をCSF2.0からCSF3.0に変更

### DIFF
--- a/react/exercise/EX/Q2/src/view/components/ControlButton/ControlButton.stories.tsx
+++ b/react/exercise/EX/Q2/src/view/components/ControlButton/ControlButton.stories.tsx
@@ -1,27 +1,24 @@
-import React from 'react';
-import { ComponentStory } from '@storybook/react';
-import NumberButton from './ControlButton';
+import type { Meta, StoryObj } from '@storybook/react';
+import ControlButton from './ControlButton';
 
 const onPush = () => {};
 
-export default {
+const meta: Meta<typeof ControlButton> = {
   title: 'components/ControlButton',
-  component: NumberButton,
+  component: ControlButton,
   args: {
     text: 'Push',
     onPush,
-    key: 'key',
   },
 };
 
-const Template: ComponentStory<typeof NumberButton> = (props) => {
-  return <NumberButton {...props} />;
-};
+export default meta;
+type Story = StoryObj<typeof ControlButton>;
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Default: Story = {};
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  disabled: true,
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
 };

--- a/react/exercise/EX/Q2/src/view/components/NumberButton/NumberButton.stories.tsx
+++ b/react/exercise/EX/Q2/src/view/components/NumberButton/NumberButton.stories.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
-import { ComponentStory } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import NumberButton from './NumberButton';
 
 const onPush = (assignedKey: string) => console.log(assignedKey);
 
-export default {
+const meta: Meta<typeof NumberButton> = {
   title: 'components/NumberButton',
   component: NumberButton,
   args: {
@@ -14,40 +13,38 @@ export default {
   },
 };
 
-const Template: ComponentStory<typeof NumberButton> = (props) => {
-  return <NumberButton {...props} />;
+export default meta;
+type Story = StoryObj<typeof NumberButton>;
+
+export const Default: Story = {};
+
+export const Normal: Story = {
+  args: {
+    type: 'default',
+  },
 };
 
-export const Default = Template.bind({});
-Default.args = {};
-
-export const Normal = Template.bind({});
-Normal.args = {
-  ...Normal.args,
-  type: 'default',
+export const Unused: Story = {
+  args: {
+    type: 'unused',
+  },
 };
 
-export const Unused = Template.bind({});
-Unused.args = {
-  ...Unused.args,
-  type: 'unused',
+export const Used: Story = {
+  args: {
+    type: 'used',
+  },
 };
 
-export const Used = Template.bind({});
-Used.args = {
-  ...Used.args,
-  type: 'used',
+export const Matched: Story = {
+  args: {
+    type: 'matched',
+  },
 };
 
-export const Matched = Template.bind({});
-Matched.args = {
-  ...Matched.args,
-  type: 'matched',
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  ...Matched.args,
-  type: 'default',
-  disabled: true,
+export const Disabled: Story = {
+  args: {
+    type: 'default',
+    disabled: true,
+  },
 };

--- a/react/exercise/EX/Q2/src/view/components/Tile/Tile.stories.tsx
+++ b/react/exercise/EX/Q2/src/view/components/Tile/Tile.stories.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { ComponentStory } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import Tile from './Tile';
 
-export default {
+// Define the component metadata
+const meta: Meta<typeof Tile> = {
   title: 'components/Tile',
   component: Tile,
   args: {
@@ -12,39 +12,38 @@ export default {
   },
 };
 
-const Template: ComponentStory<typeof Tile> = (props) => {
-  return <Tile {...props} />;
+export default meta;
+type Story = StoryObj<typeof Tile>;
+
+export const Default: Story = {};
+
+export const Normal: Story = {
+  args: {
+    type: 'default',
+  },
 };
 
-export const Default = Template.bind({});
-Default.args = {};
-
-export const Normal = Template.bind({});
-Normal.args = {
-  ...Normal.args,
-  type: 'default',
+export const Unused: Story = {
+  args: {
+    type: 'unused',
+  },
 };
 
-export const Unused = Template.bind({});
-Unused.args = {
-  ...Unused.args,
-  type: 'unused',
+export const Used: Story = {
+  args: {
+    type: 'used',
+  },
 };
 
-export const Used = Template.bind({});
-Used.args = {
-  ...Used.args,
-  type: 'used',
+export const Matched: Story = {
+  args: {
+    type: 'matched',
+  },
 };
 
-export const Matched = Template.bind({});
-Matched.args = {
-  ...Matched.args,
-  type: 'matched',
-};
-
-export const Selected = Template.bind({});
-Selected.args = {
-  ...Normal.args,
-  selected: true,
+export const Selected: Story = {
+  args: {
+    type: 'default',
+    selected: true,
+  },
 };

--- a/react/exercise/EX/Q2/src/view/containers/Main/Main.stories.tsx
+++ b/react/exercise/EX/Q2/src/view/containers/Main/Main.stories.tsx
@@ -1,14 +1,12 @@
-import React from 'react';
-import { ComponentStory } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import Main from './Main';
 
-export default {
+const meta: Meta<typeof Main> = {
   title: 'containers/Main',
   component: Main,
 };
 
-const Template: ComponentStory<typeof Main> = (props) => {
-  return <Main {...props} />;
-};
+export default meta;
+type Story = StoryObj<typeof Main>;
 
-export const Default = Template.bind({});
+export const Default: Story = {};

--- a/react/exercise/EX/Q2/src/view/layouts/ControlButtonGrid/ControlButtonGrid.stories.tsx
+++ b/react/exercise/EX/Q2/src/view/layouts/ControlButtonGrid/ControlButtonGrid.stories.tsx
@@ -1,23 +1,23 @@
-import React from 'react';
-import { ComponentStory } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import ControlButtonGrid from './ControlButtonGrid';
 import ControlButton from '../../components/ControlButton';
 
 const onPush = () => console.log();
 
-export default {
+const meta: Meta<typeof ControlButtonGrid> = {
   title: 'layouts/ControlButtonGrid',
   component: ControlButtonGrid,
 };
 
-const Template: ComponentStory<typeof ControlButtonGrid> = () => {
-  return (
+export default meta;
+type Story = StoryObj<typeof ControlButtonGrid>;
+
+export const Default: Story = {
+  render: () => (
     <ControlButtonGrid>
       <ControlButton assignedKey={'a'} text={'A'} onPush={onPush} key={'a'} />
       <ControlButton assignedKey={'b'} text={'B'} onPush={onPush} key={'b'} />
       <ControlButton assignedKey={'c'} text={'C'} onPush={onPush} key={'c'} />
     </ControlButtonGrid>
-  );
+  ),
 };
-
-export const Default = Template.bind({});

--- a/react/exercise/EX/Q2/src/view/layouts/MainGrid/MainGrid.stories.tsx
+++ b/react/exercise/EX/Q2/src/view/layouts/MainGrid/MainGrid.stories.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { ComponentStory } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import MainGrid from './MainGrid';
 
 const getStyle = (background: string, height: string) => ({
@@ -9,13 +8,16 @@ const getStyle = (background: string, height: string) => ({
   fontSize: '0.25rem',
 });
 
-export default {
+const meta: Meta<typeof MainGrid> = {
   title: 'layouts/MainGrid',
   component: MainGrid,
 };
 
-const Template: ComponentStory<typeof MainGrid> = () => {
-  return (
+export default meta;
+type Story = StoryObj<typeof MainGrid>;
+
+export const Default: Story = {
+  render: () => (
     <MainGrid>
       <div style={getStyle('red', '1.2rem')}>message</div>
       <div style={getStyle('yellow', '4rem')}>tile</div>
@@ -23,7 +25,5 @@ const Template: ComponentStory<typeof MainGrid> = () => {
       <div style={getStyle('blue', '1.6rem')}>number</div>
       <div style={getStyle('purple', '.8rem')}>control</div>
     </MainGrid>
-  );
+  ),
 };
-
-export const Default = Template.bind({});

--- a/react/exercise/EX/Q2/src/view/layouts/NumberButtonGrid/NumberButtonGrid.stories.tsx
+++ b/react/exercise/EX/Q2/src/view/layouts/NumberButtonGrid/NumberButtonGrid.stories.tsx
@@ -1,21 +1,21 @@
-import React from 'react';
-import { ComponentStory } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import NumberButtonGrid from './NumberButtonGrid';
 import NumberButton from '../../components/NumberButton';
 
 const onPush = (assignedKey: string) => console.log(assignedKey);
 
-export default {
+const buttons = [...new Array(10)].map((_, index) => (
+  <NumberButton assignedKey={`${index}`} text={`${index}`} onPush={onPush} key={index} />
+));
+
+const meta: Meta<typeof NumberButtonGrid> = {
   title: 'layouts/NumberButtonGrid',
   component: NumberButtonGrid,
 };
 
-const buttons = [...new Array(10)].map((_, index) => (
-  <NumberButton assignedKey={`${index}`} text={`${index}`} onPush={onPush} />
-));
+export default meta;
+type Story = StoryObj<typeof NumberButtonGrid>;
 
-const Template: ComponentStory<typeof NumberButtonGrid> = () => {
-  return <NumberButtonGrid>{buttons}</NumberButtonGrid>;
+export const Default: Story = {
+  render: () => <NumberButtonGrid>{buttons}</NumberButtonGrid>,
 };
-
-export const Default = Template.bind({});

--- a/react/exercise/EX/Q2/src/view/layouts/TileGrid/TileGrid.stories.tsx
+++ b/react/exercise/EX/Q2/src/view/layouts/TileGrid/TileGrid.stories.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
-import { ComponentStory } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import TileGrid from './TileGrid';
 import Tile from '../../components/Tile';
-
-export default {
-  title: 'layouts/TileGrid',
-  component: TileGrid,
-};
 
 const getTiles = (col: number, row: number) =>
   [...new Array(col * row)].map((_, index) => <Tile key={`tile-${index}`} />);
 
-const Template: ComponentStory<typeof TileGrid> = () => {
-  return <TileGrid>{getTiles(5, 5)}</TileGrid>;
+const meta: Meta<typeof TileGrid> = {
+  title: 'layouts/TileGrid',
+  component: TileGrid,
 };
 
-export const Default = Template.bind({});
+export default meta;
+type Story = StoryObj<typeof TileGrid>;
+
+export const Default: Story = {
+  render: () => <TileGrid>{getTiles(5, 5)}</TileGrid>,
+};


### PR DESCRIPTION
<!-- 日本語でレビューしてください -->

# 注意

Public リポジトリなので社内の情報をコミットしないでください。

## 更新内容

型エラーになっていたため、EX/Q2のstorybookの記載形式をCSF2.0からCSF3.0に変更して解決しました。(CSFとはComponent Story Formatの略で、Storyファイルでのコンポーネントの書き方の形式です。)
- https://github.com/access-company/webfrontend_intro/pull/66 にてstorybookのバージョンをv7からv8に上げたため、Storybookファイルで型エラーになっていました。CSF3.0形式で書き直すことでエラーが解消されました。
  - 型エラーになっていたのは全ての"XXX.story.tsx"のファイルの `import { ComponentStory } from '@storybook/react';`です。`'"@storybook/react"' has no exported member named 'ComponentStory'.`のエラーになっていました。
- ComponentStory型は、CSF2.0という形式でStoryを書くときに使われる型であり、v8ではCSF2.0が非推奨になったため型エラーになっていたと思われます。CSF3.0にすることで、ComponentStory型を使う必要がなくなりました。
  - 参考： [Migration guide for Storybook 8.0](https://storybook.js.org/docs/migration-guide#optional-migrations)

## 補足
- CSF2.0から3.0に変更することで動作に影響はありません。一番のCSF3.0のおいしさは、Storyを書きやすくなることです。
- [slack](https://accessjp.slack.com/archives/CDEQF789Z/p1747452458476529)ではStorybookが動作しないと伝えていたのですが、これは誤りで、動作はしていました。
- [slack](https://accessjp.slack.com/archives/CDEQF789Z/p1747452458476529)では https://github.com/access-company/webfrontend_intro/pull/73 が原因だと伝えていたのですが、これは誤りでした。
